### PR TITLE
Add MacOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Intended use is registering neuroimaging data from one individual to a standard 
 
 This code was originally published [here](https://github.com/htem/GridTape_VNC_paper/tree/main/template_registration_pipeline/run_elastix) as part of [Phelps, Hildebrand, Graham et al. 2021](https://www.lee.hms.harvard.edu/phelps-hildebrand-graham-et-al-2021). Continued development of this code will continue here, not in the paper's repository.
 
+Currently runs on Linux (tested on Ubuntu) and Mac (tested on Big Sur).
+
 ---
 
 ## Usage Manual

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Intended use is registering neuroimaging data from one individual to a standard 
 
 This code was originally published [here](https://github.com/htem/GridTape_VNC_paper/tree/main/template_registration_pipeline/run_elastix) as part of [Phelps, Hildebrand, Graham et al. 2021](https://www.lee.hms.harvard.edu/phelps-hildebrand-graham-et-al-2021). Continued development of this code will continue here, not in the paper's repository.
 
-Currently runs on Linux (tested on Ubuntu) and Mac (tested on Big Sur).
+Currently runs on Linux (tested on Ubuntu 16.04, 18.04, and 20.04, but see notes below about which version of elastix is compatible with each OS version) and Mac (tested on Big Sur).
 
 ---
 
 ## Usage Manual
 
 ### Step 0: Prerequisites
-**A.** Download [elastix](https://elastix.lumc.nl/download.php) from its [releases page](https://github.com/SuperElastix/elastix/releases). Extract the folder from the .zip or .tar.gz file and put that folder somewhere on your computer.
+**A.** Download [elastix](https://elastix.lumc.nl/download.php) from its [releases page](https://github.com/SuperElastix/elastix/releases). Extract the folder from the .zip or .tar.gz file and put that folder somewhere on your computer. (Ubuntu 16.04: Use elastix-4.9.0. Ubuntu 18.04: Use elastix-5.0.0. Ubuntu 20.04: Use elastix-5.0.1. Mac: Use the most recent version.)
 
 **B.** Open the file `run_elastix_settings` in this folder and change the line starting with `elastix_installation_location=` to be wherever you put the extracted folder from step A. (The default value is `~/software`, so consider putting your elastix folder on your computer at that location.)
 

--- a/invert_elastix
+++ b/invert_elastix
@@ -1,10 +1,23 @@
 #!/bin/bash
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Configure paths and default parameters
+source run_elastix_settings
+elastix_folder=$(ls $elastix_installation_location/elastix-*/bin/elastix)
+if [ -z "$elastix_folder" ]; then
+    >&2 echo "elastix could not be found in $elastix_installation_location"
+    >&2 echo "Make sure you have downloaded elastix and then edited ${SCRIPT_DIR}/run_elastix_settings to specify where you put the elastix files"
+    exit 1
+fi
+elastix_folder=${elastix_folder%/bin/elastix}
+export PATH=$elastix_folder/bin:$PATH
+export LD_LIBRARY_PATH=$elastix_folder/lib
+
+
 show_help () {
     >&2 echo "Usage: invert_elastix folder_containing_transform_to_invert [-v] [-f] [-o output_suffix] [-n n_threads] [-s spacings] [-w]"
     >&2 echo "Example: ./invert_elastix ../motor_neurons/21G01-LexA/21G01LexA_vnc2_60x_T1_2019_09_19_neuropil_elastix_to_moving_template/elastix_Bspline/4spacing_20bendingweight"
-    >&2 echo "        Description goes here"
-    >&2 echo "        and can continue here"
 }
 
 if [ "$#" -eq 0 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
@@ -12,12 +25,23 @@ if [ "$#" -eq 0 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
     exit 1
 fi
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if [ ! -f ${SCRIPT_DIR}/elastixParams_InvertBspline.txt ]; then
     show_help
-    >&2 echo "ERROR: elastixParams_InvertBspline.txt must exist in current directory"
+    >&2 echo "ERROR: elastixParams_InvertBspline.txt must exist in ${SCRIPT_DIR}"
     exit 1
 fi
+
+
+# Check whether the GNU sed or BSD/MacOS sed is installed and use
+# the form of the -i argument required by the detected version
+# Information from https://stackoverflow.com/a/44864004
+# Implementation from https://stackoverflow.com/a/9323261
+if sed --version &> /dev/null; then
+    dashi=(-i)  # GNU sed
+else
+    dashi=(-i "")  # BSD/MacOS sed
+fi
+
 
 #DEFAULTS FOR ARGUMENT-MODIFIABLE VARIABLES GO HERE
 verbose=false
@@ -167,8 +191,8 @@ for spacing in $spacings; do
         case $input in [yY]) echo "Overwriting"; chmod +w "$elastixParams";; *) echo "Exiting"; exit 1 ;; esac
     fi 
     cp "${SCRIPT_DIR}/elastixParams_InvertBspline.txt" "$elastixParams"
-    sed -i "s/(FinalGridSpacingInPhysicalUnits _GRIDSPACING_)/(FinalGridSpacingInPhysicalUnits $spacing)/" "$elastixParams"
-    if $write_intermediate_output; then sed -i 's/(WriteResultImage "false")/(WriteResultImage "true")/' "$elastixParams"; fi
+    sed "${dashi[@]}" "s/(FinalGridSpacingInPhysicalUnits _GRIDSPACING_)/(FinalGridSpacingInPhysicalUnits $spacing)/" "$elastixParams"
+    if $write_intermediate_output; then sed "${dashi[@]}" 's/(WriteResultImage "false")/(WriteResultImage "true")/' "$elastixParams"; fi
     $chmod -w "$elastixParams"
 
     echo "Inverting $base/TransformParameters.0.txt with GridSpacing $spacing"
@@ -187,7 +211,7 @@ for spacing in $spacings; do
     if [ -f "$output_folder/result.0.nrrd" ]; then $mv "$output_folder/result.0.nrrd" "$output_folder/result.0.composedForwardAndInverseTransforms.nrrd"; fi
 
     $cp "$output_folder/TransformParameters.0.txt" "$output_folder/TransformParameters.1.txt"
-    $sed -i 's/(InitialTransformParametersFileName.*)/(InitialTransformParametersFileName "NoInitialTransform")/' "$output_folder/TransformParameters.1.txt"
+    $sed "${dashi[@]}" 's/(InitialTransformParametersFileName.*)/(InitialTransformParametersFileName "NoInitialTransform")/' "$output_folder/TransformParameters.1.txt"
 
     #Apply the inverted transform to the fixed image
     $transformix -in "$fixed" \

--- a/invert_elastix
+++ b/invert_elastix
@@ -31,6 +31,12 @@ if [ ! -f ${SCRIPT_DIR}/elastixParams_InvertBspline.txt ]; then
     exit 1
 fi
 
+# For compatibility with systems where realpath is not installed
+if ! which realpath &> /dev/null; then
+    realpath() {
+        echo "$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
+    }
+fi
 
 # Check whether the GNU sed or BSD/MacOS sed is installed and use
 # the form of the -i argument required by the detected version

--- a/invert_elastix
+++ b/invert_elastix
@@ -2,17 +2,59 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Configure paths and default parameters
-source run_elastix_settings
-elastix_folder=$(ls $elastix_installation_location/elastix-*/bin/elastix)
-if [ -z "$elastix_folder" ]; then
-    >&2 echo "elastix could not be found in $elastix_installation_location"
-    >&2 echo "Make sure you have downloaded elastix and then edited ${SCRIPT_DIR}/run_elastix_settings to specify where you put the elastix files"
-    exit 1
+# For compatibility with systems where realpath is not installed, e.g. MacOS.
+if ! which realpath &> /dev/null; then
+    realpath() {
+        path="$1"
+        # First, if the file is a symlink, recursively resolve it
+        while [ -L "$path" ]; do
+            link_path=$(readlink $path)
+            case ${link_path:0:1} in
+                "/") path="$link_path" ;;
+                "~") path="$link_path" ;;
+                *) path="$(dirname "$path")/$link_path"
+            esac
+        done
+        # Then resolve folder symlinks and ".." and other junk in the full path
+        echo "$(cd "$(dirname "$path")" && pwd -P)/$(basename "$1")"
+    }
 fi
-elastix_folder=${elastix_folder%/bin/elastix}
-export PATH=$elastix_folder/bin:$PATH
-export LD_LIBRARY_PATH=$elastix_folder/lib
+
+# Load run_elastix settings
+source run_elastix_settings
+
+# Configure elastix path
+if which elastix > /dev/null; then
+    elastix_path=$(which elastix)
+    echo "Using elastix found on the PATH: $elastix_path"
+else
+    elastix_path=$(ls $elastix_installation_location/elastix*/bin/elastix)
+    n_elastix_found=$(ls $elastix_installation_location/elastix*/bin/elastix | wc -l)
+    if [ "$n_elastix_found" -eq 0 ]; then
+        >&2 echo "elastix could not be found at $elastix_installation_location/elastix*/bin/elastix"
+        >&2 echo "Make sure you have downloaded elastix and then edited ${SCRIPT_DIR}/run_elastix_settings to specify where you put the elastix files"
+        >&2 echo "See README.md for more details"
+        exit 1
+    elif [ "$n_elastix_found" -gt 1 ]; then
+        >&2 echo "$n_elastix_found elastix executables found in $elastix_installation_location:"
+        >&2 echo $elastix_path
+        elastix_path=$(ls -t $elastix_installation_location/elastix*/bin/elastix | head -n 1)
+        >&2 echo "Using the version with the most recent timestamp: $elastix_path"
+    else
+        >&2 echo "Using elastix found at: $elastix_path"
+    fi
+    # Add the folder containing elastix to the path
+    export PATH=$(dirname "$elastix_path"):$PATH
+fi
+
+# Due to MacOS System Integrity Protection purging LD_* environment variables,
+# we set it explicitly here so that elastix can find is library file
+# libANNlib-5.0. Doing this also makes sure elastix will work on other OSes
+# even if the user hasn't set their LD_LIBRARY_PATH to point to the folder
+# containing elastix's libANNlib-5.0 
+elastix_path=$(realpath $elastix_path)
+# Allow elastix to search for libANNlib-5.0 in the elastix folder and in ../lib
+export LD_LIBRARY_PATH=$(dirname "$elastix_path"):$(dirname "$(dirname "$elastix_path")")/lib
 
 
 show_help () {
@@ -29,13 +71,6 @@ if [ ! -f ${SCRIPT_DIR}/elastixParams_InvertBspline.txt ]; then
     show_help
     >&2 echo "ERROR: elastixParams_InvertBspline.txt must exist in ${SCRIPT_DIR}"
     exit 1
-fi
-
-# For compatibility with systems where realpath is not installed
-if ! which realpath &> /dev/null; then
-    realpath() {
-        echo "$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
-    }
 fi
 
 # Check whether the GNU sed or BSD/MacOS sed is installed and use

--- a/run_elastix
+++ b/run_elastix
@@ -68,6 +68,19 @@ if ! which realpath &> /dev/null; then
     }
 fi
 
+# Check whether the GNU sed or BSD/MacOS sed is installed and use
+# the form of the -i argument required by the detected version
+# Information from https://stackoverflow.com/a/44864004
+# Implementation from https://stackoverflow.com/a/9323261
+if sed --version &> /dev/null; then
+    dashi=(-i)  # GNU sed
+else
+    dashi=(-i "")  # BSD/MacOS sed
+fi
+
+
+
+
 #DEFAULTS FOR ARGUMENT-MODIFIABLE VARIABLES GO HERE
 verbose=false
 fake=false
@@ -298,11 +311,11 @@ if $run_affine; then
     fi
     cp ${SCRIPT_DIR}/elastixParams_Affine.txt $elastixParams_affine
     if $suppress_image_writing; then
-        sed -i 's/(WriteResultImage "true")/(WriteResultImage "false")/' $elastixParams_affine
+        sed "${dashi[@]}" 's/(WriteResultImage "true")/(WriteResultImage "false")/' $elastixParams_affine
     fi
     if [ -n "$points" -a -n "$template_points" ]; then
-        sed -i 's/(Metric "AdvancedNormalizedCorrelation")/(Metric "AdvancedNormalizedCorrelation" "CorrespondingPointsEuclideanDistanceMetric")\r\n(Metric0Weight 1)\r\n(Metric1Weight 0.01)/' $elastixParams_affine
-        sed -i 's/\/\/(Metric1Use/(Metric1Use/' $elastixParams_affine
+        sed "${dashi[@]}" 's/(Metric "AdvancedNormalizedCorrelation")/(Metric "AdvancedNormalizedCorrelation" "CorrespondingPointsEuclideanDistanceMetric")\r\n(Metric0Weight 1)\r\n(Metric1Weight 0.01)/' $elastixParams_affine
+        sed "${dashi[@]}" 's/\/\/(Metric1Use/(Metric1Use/' $elastixParams_affine
         cp "$points" "$template_points" "$output/elastix_affine/"
     fi
     $chmod -w $elastixParams_affine
@@ -334,7 +347,7 @@ if $run_Bspline; then
         exit 1
     fi
 
-    if [ ! -e "$affine_transformation_parameters" ]; then
+    if ! $fake && [ ! -e "$affine_transformation_parameters" ]; then
         show_help
         >&2 echo "ERROR: Affine transformation parameters must exist at $affine_transformation_parameters before running Bspline alignment."
         $exit 1
@@ -353,17 +366,17 @@ if $run_Bspline; then
                 case $input in [yY]) echo "Overwriting"; chmod +w $elastixParams_Bspline ;; *) echo "Exiting"; exit 1 ;; esac
             fi
             cp ${SCRIPT_DIR}/elastixParams_Bspline.txt $elastixParams_Bspline
-            sed -i "s/(FinalGridSpacingInPhysicalUnits _GRIDSPACING_)/(FinalGridSpacingInPhysicalUnits $spacing)/" $elastixParams_Bspline
+            sed "${dashi[@]}" "s/(FinalGridSpacingInPhysicalUnits _GRIDSPACING_)/(FinalGridSpacingInPhysicalUnits $spacing)/" $elastixParams_Bspline
             if $suppress_image_writing; then
-                sed -i 's/(WriteResultImage "true")/(WriteResultImage "false")/' $elastixParams_Bspline
+                sed "${dashi[@]}" 's/(WriteResultImage "true")/(WriteResultImage "false")/' $elastixParams_Bspline
             fi
             if [ -n "$points" -a -n "$template_points" ]; then
-                sed -i 's/(Metric "AdvancedNormalizedCorrelation" "TransformBendingEnergyPenalty")/(Metric "AdvancedNormalizedCorrelation" "TransformBendingEnergyPenalty" "CorrespondingPointsEuclideanDistanceMetric")/' $elastixParams_Bspline
-                sed -i 's/\/\/(Metric2Weight/(Metric2Weight/' $elastixParams_Bspline
-                sed -i 's/\/\/(Metric2Use/(Metric2Use/' $elastixParams_Bspline
+                sed "${dashi[@]}" 's/(Metric "AdvancedNormalizedCorrelation" "TransformBendingEnergyPenalty")/(Metric "AdvancedNormalizedCorrelation" "TransformBendingEnergyPenalty" "CorrespondingPointsEuclideanDistanceMetric")/' $elastixParams_Bspline
+                sed "${dashi[@]}" 's/\/\/(Metric2Weight/(Metric2Weight/' $elastixParams_Bspline
+                sed "${dashi[@]}" 's/\/\/(Metric2Use/(Metric2Use/' $elastixParams_Bspline
                 cp "$points" "$template_points" "$this_run_output/"
             fi
-            sed -i "s/(Metric1Weight _METRIC1WEIGHT_)/(Metric1Weight $bending_weight)/" $elastixParams_Bspline
+            sed "${dashi[@]}" "s/(Metric1Weight _METRIC1WEIGHT_)/(Metric1Weight $bending_weight)/" $elastixParams_Bspline
             $chmod -w $elastixParams_Bspline
 
             echo "elastix with BSPLINE TRANSFORM saving to $this_run_output"
@@ -377,7 +390,7 @@ if $run_Bspline; then
                 -threads $n_cores \
                 -p "$elastixParams_Bspline"
 
-            $ln -s ${spacing}spacing_${bending_weight}bendingweight${output_suffix}/result.0.nrrd $output/elastix_Bspline/result.${spacing}spacing_${bending_weight}bendingweight${output_suffix}.nrrd
+            $ln -s ${spacing}spacing_${bending_weight}bendingweight${output_suffix}/result.0.nrrd $output/elastix_Bspline/result.${spacing}spacing_${bending_weight}bendingweight${output_suffix}.nrrd 2> /dev/null
             echo
         done
     done

--- a/run_elastix
+++ b/run_elastix
@@ -47,14 +47,14 @@ else
     export PATH=$(dirname "$elastix_path"):$PATH
 fi
 
-# Due to MacOS System Integrity Protection purging LD_* environment variables, we
-# set it explicitly here. Doing this also makes sure elastix will work on other OSes
-# even if the user hasn't set their LD_LIBRARY_PATH to point to the folder containing
-# elastix's libANNlib-5.0.so
+# Due to MacOS System Integrity Protection purging LD_* environment variables,
+# we set it explicitly here so that elastix can find is library file
+# libANNlib-5.0. Doing this also makes sure elastix will work on other OSes
+# even if the user hasn't set their LD_LIBRARY_PATH to point to the folder
+# containing elastix's libANNlib-5.0 
 elastix_path=$(realpath $elastix_path)
-# Allow elastix to search for libANNlib-5.0.so in the elastix folder and in ../lib
+# Allow elastix to search for libANNlib-5.0 in the elastix folder and in ../lib
 export LD_LIBRARY_PATH=$(dirname "$elastix_path"):$(dirname "$(dirname "$elastix_path")")/lib
-echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 
 show_help () {

--- a/run_elastix
+++ b/run_elastix
@@ -2,17 +2,59 @@
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Configure paths and default parameters
-source run_elastix_settings
-elastix_folder=$(ls $elastix_installation_location/elastix-*/bin/elastix)
-if [ -z "$elastix_folder" ]; then
-    >&2 echo "elastix could not be found in $elastix_installation_location"
-    >&2 echo "Make sure you have downloaded elastix and then edited ${SCRIPT_DIR}/run_elastix_settings to specify where you put the elastix files"
-    exit 1
+# For compatibility with systems where realpath is not installed, e.g. MacOS.
+if ! which realpath &> /dev/null; then
+    realpath() {
+        path="$1"
+        # First, if the file is a symlink, recursively resolve it
+        while [ -L "$path" ]; do
+            link_path=$(readlink $path)
+            case ${link_path:0:1} in
+                "/") path="$link_path" ;;
+                "~") path="$link_path" ;;
+                *) path="$(dirname "$path")/$link_path"
+            esac
+        done
+        # Then resolve folder symlinks and ".." and other junk in the full path
+        echo "$(cd "$(dirname "$path")" && pwd -P)/$(basename "$1")"
+    }
 fi
-elastix_folder=${elastix_folder%/bin/elastix}
-export PATH=$elastix_folder/bin:$PATH
-export LD_LIBRARY_PATH=$elastix_folder/lib
+
+# Load run_elastix settings
+source run_elastix_settings
+
+# Configure elastix path
+if which elastix > /dev/null; then
+    elastix_path=$(which elastix)
+    echo "Using elastix found on the PATH: $elastix_path"
+else
+    elastix_path=$(ls $elastix_installation_location/elastix*/bin/elastix)
+    n_elastix_found=$(ls $elastix_installation_location/elastix*/bin/elastix | wc -l)
+    if [ "$n_elastix_found" -eq 0 ]; then
+        >&2 echo "elastix could not be found at $elastix_installation_location/elastix*/bin/elastix"
+        >&2 echo "Make sure you have downloaded elastix and then edited ${SCRIPT_DIR}/run_elastix_settings to specify where you put the elastix files"
+        >&2 echo "See README.md for more details"
+        exit 1
+    elif [ "$n_elastix_found" -gt 1 ]; then
+        >&2 echo "$n_elastix_found elastix executables found in $elastix_installation_location:"
+        >&2 echo $elastix_path
+        elastix_path=$(ls -t $elastix_installation_location/elastix*/bin/elastix | head -n 1)
+        >&2 echo "Using the version with the most recent timestamp: $elastix_path"
+    else
+        >&2 echo "Using elastix found at: $elastix_path"
+    fi
+    # Add the folder containing elastix to the path
+    export PATH=$(dirname "$elastix_path"):$PATH
+fi
+
+# Due to MacOS System Integrity Protection purging LD_* environment variables, we
+# set it explicitly here. Doing this also makes sure elastix will work on other OSes
+# even if the user hasn't set their LD_LIBRARY_PATH to point to the folder containing
+# elastix's libANNlib-5.0.so
+elastix_path=$(realpath $elastix_path)
+# Allow elastix to search for libANNlib-5.0.so in the elastix folder and in ../lib
+export LD_LIBRARY_PATH=$(dirname "$elastix_path"):$(dirname "$(dirname "$elastix_path")")/lib
+echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 
 
 show_help () {
@@ -61,12 +103,6 @@ if [ "$1" == "manual" ]; then
     exit 1
 fi
 
-# For compatibility with systems where realpath is not installed
-if ! which realpath &> /dev/null; then
-    realpath() {
-        echo "$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
-    }
-fi
 
 # Check whether the GNU sed or BSD/MacOS sed is installed and use
 # the form of the -i argument required by the detected version

--- a/run_elastix
+++ b/run_elastix
@@ -61,6 +61,12 @@ if [ "$1" == "manual" ]; then
     exit 1
 fi
 
+# For compatibility with systems where realpath is not installed
+if ! which realpath &> /dev/null; then
+    realpath() {
+        echo "$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
+    }
+fi
 
 #DEFAULTS FOR ARGUMENT-MODIFIABLE VARIABLES GO HERE
 verbose=false


### PR DESCRIPTION
Since elastix released a Mac-compatible version as of elastix-5.0.0 (see https://github.com/SuperElastix/elastix/releases), I reworked `run_elastix` and `invert_elastix` to be able to run on both Linux and Mac. Mainly involved dealing with slight differences in builtin function behavior (`sed`) or lack of function availability on Mac (`realpath`) or Mac-specific path stuff (`LD_LIBRARY_PATH` not getting passed to subprocesses due to System Integrity Protection)